### PR TITLE
Rewrite implementation of clean

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,10 @@ keywords = ["path", "clean"]
 exclude = ["scripts/*"]
 
 [dependencies]
+
+[dev-dependencies]
+criterion = "0.2"
+
+[[bench]]
+name = "clean_benchmark"
+harness = false

--- a/benches/clean_benchmark.rs
+++ b/benches/clean_benchmark.rs
@@ -1,0 +1,18 @@
+#[macro_use]
+extern crate criterion;
+
+extern crate path_clean;
+
+use criterion::black_box;
+use criterion::Criterion;
+
+use path_clean::clean;
+
+fn clean_benchmark(c: &mut Criterion) {
+    c.bench_function("clean", |b| {
+        b.iter(|| clean(black_box("abc/../../././../def")))
+    });
+}
+
+criterion_group!(benches, clean_benchmark);
+criterion_main!(benches);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,10 +57,10 @@ pub fn clean(path: &str) -> String {
 }
 
 fn clean_internal(path: &[u8]) -> Vec<u8> {
-    static DOT: u8 = '.' as u8;
-    static SEP: u8 = '/' as u8;
+    static DOT: u8 = b'.';
+    static SEP: u8 = b'/';
 
-    if path.len() == 0 {
+    if path.is_empty() {
         return vec![DOT];
     }
 
@@ -86,11 +86,8 @@ fn clean_internal(path: &[u8]) -> Vec<u8> {
     }
 
     while r < n {
-        if path[r] == SEP {
-            // empty path element: skip
-            r += 1;
-        } else if path[r] == DOT && (r + 1 == n || path[r + 1] == SEP) {
-            // . element: skip
+        if path[r] == SEP || path[r] == DOT && (r + 1 == n || path[r + 1] == SEP) {
+            // empty path element || . element: skip
             r += 1;
         } else if path[r] == DOT && path[r + 1] == DOT && (r + 2 == n || path[r + 2] == SEP) {
             // .. element: remove to last separator
@@ -104,7 +101,7 @@ fn clean_internal(path: &[u8]) -> Vec<u8> {
                 out.truncate(w);
             } else if !rooted {
                 // cannot backtrack, but not rooted, so append .. element
-                if out.len() > 0 {
+                if !out.is_empty() {
                     out.push(SEP);
                 }
                 out.push(DOT);
@@ -114,7 +111,7 @@ fn clean_internal(path: &[u8]) -> Vec<u8> {
         } else {
             // real path element
             // add slash if needed
-            if rooted && out.len() != 1 || !rooted && out.len() != 0 {
+            if rooted && out.len() != 1 || !rooted && !out.is_empty() {
                 out.push(SEP);
             }
             while r < n && path[r] != SEP {
@@ -125,7 +122,7 @@ fn clean_internal(path: &[u8]) -> Vec<u8> {
     }
 
     // Turn empty string into "."
-    if out.len() == 0 {
+    if out.is_empty() {
         out.push(DOT);
     }
     out

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,14 +40,6 @@ impl PathClean<PathBuf> for PathBuf {
     }
 }
 
-/// The core implementation. It performs the following, lexically:
-/// 1. Reduce multiple slashes to a single slash.
-/// 2. Eliminate `.` path name elements (the current directory).
-/// 3. Eliminate `..` path name elements (the parent directory) and the non-`.` non-`..`, element that precedes them.
-/// 4. Eliminate `..` elements that begin a rooted path, that is, replace `/..` by `/` at the beginning of a path.
-/// 5. Leave intact `..` elements that begin a non-rooted path.
-///
-/// If the result of this process is an empty string, return the string `"."`, representing the current directory.
 pub fn clean(path: &str) -> String {
     let out = clean_internal(path.as_bytes());
     // The code only matches/modifies ascii tokens and leaves the rest of
@@ -56,6 +48,14 @@ pub fn clean(path: &str) -> String {
     unsafe { String::from_utf8_unchecked(out) }
 }
 
+/// The core implementation. It performs the following, lexically:
+/// 1. Reduce multiple slashes to a single slash.
+/// 2. Eliminate `.` path name elements (the current directory).
+/// 3. Eliminate `..` path name elements (the parent directory) and the non-`.` non-`..`, element that precedes them.
+/// 4. Eliminate `..` elements that begin a rooted path, that is, replace `/..` by `/` at the beginning of a path.
+/// 5. Leave intact `..` elements that begin a non-rooted path.
+///
+/// If the result of this process is an empty string, return the string `"."`, representing the current directory.
 fn clean_internal(path: &[u8]) -> Vec<u8> {
     static DOT: u8 = b'.';
     static SEP: u8 = b'/';


### PR DESCRIPTION
Hey, I was thinking of creating a crate like this, but saw that you already had! This commit is roughly the code from the version I was working on. It was ripped almost directly from the the go stdlib `path.Clean` implementation so it's pretty battle tested in that sense. And it's 6x faster according to criterion, though maybe less clear in its correctness.

I use unsafe for casting the returned `Vec<u8>` to `String`, and I'm certain it's completely safe but understand if want to keep unsafe out.