### PR TITLE
RFC: Lexicographical path cleaning using the path type of the standard library.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,34 +18,26 @@
 //! ```rust
 //! use std::path::PathBuf;
 //! use path_clean::{clean, PathClean};
-//! assert_eq!(clean("hello/world/.."), "hello");
+//! assert_eq!(clean("hello/world/.."), PathBuf::from("hello"));
 //! assert_eq!(
 //!     PathBuf::from("/test/../path/").clean(),
 //!     PathBuf::from("/path")
 //! );
 //! ```
+#![forbid(unsafe_code)]
 
-use std::path::PathBuf;
+use std::path::{Component, Path, PathBuf};
 
-/// The Clean trait implements a `clean` method. It's recommended you use the provided [`clean`]
-/// function.
-pub trait PathClean<T> {
-    fn clean(&self) -> T;
+/// The Clean trait implements a `clean` method.
+pub trait PathClean {
+    fn clean(&self) -> PathBuf;
 }
 
-/// PathClean implemented for PathBuf
-impl PathClean<PathBuf> for PathBuf {
+/// PathClean implemented for `Path`
+impl PathClean for Path {
     fn clean(&self) -> PathBuf {
-        PathBuf::from(clean(self.to_str().unwrap_or("")))
+        clean(self)
     }
-}
-
-pub fn clean(path: &str) -> String {
-    let out = clean_internal(path.as_bytes());
-    // The code only matches/modifies ascii tokens and leaves the rest of
-    // the bytes as they are, so if the input string is valid utf8 the result
-    // will also be valid utf8.
-    unsafe { String::from_utf8_unchecked(out) }
 }
 
 /// The core implementation. It performs the following, lexically:
@@ -56,76 +48,36 @@ pub fn clean(path: &str) -> String {
 /// 5. Leave intact `..` elements that begin a non-rooted path.
 ///
 /// If the result of this process is an empty string, return the string `"."`, representing the current directory.
-fn clean_internal(path: &[u8]) -> Vec<u8> {
-    static DOT: u8 = b'.';
-    static SEP: u8 = b'/';
+pub fn clean<P>(path: P) -> PathBuf
+where
+    P: AsRef<Path>,
+{
+    let mut out = Vec::new();
 
-    if path.is_empty() {
-        return vec![DOT];
-    }
-
-    let rooted = path[0] == SEP;
-    let n = path.len();
-
-    // Invariants:
-    //  - reading from path; r is index of next byte to process.
-    //  - dotdot is index in out where .. must stop, either because it is the
-    //    leading slash or it is a leading ../../.. prefix.
-    //
-    // The go code this function is based on handles already-clean paths without
-    // an allocation, but I haven't done that here because I think it
-    // complicates the return signature too much.
-    let mut out: Vec<u8> = Vec::with_capacity(n);
-    let mut r = 0;
-    let mut dotdot = 0;
-
-    if rooted {
-        out.push(SEP);
-        r = 1;
-        dotdot = 1
-    }
-
-    while r < n {
-        if path[r] == SEP || path[r] == DOT && (r + 1 == n || path[r + 1] == SEP) {
-            // empty path element || . element: skip
-            r += 1;
-        } else if path[r] == DOT && path[r + 1] == DOT && (r + 2 == n || path[r + 2] == SEP) {
-            // .. element: remove to last separator
-            r += 2;
-            if out.len() > dotdot {
-                // can backtrack, truncate to last separator
-                let mut w = out.len() - 1;
-                while w > dotdot && out[w] != SEP {
-                    w -= 1;
+    for comp in path.as_ref().components() {
+        match comp {
+            Component::CurDir => (),
+            Component::ParentDir => match out.last() {
+                Some(Component::RootDir) => (),
+                Some(Component::CurDir) | Some(Component::ParentDir) => out.push(comp),
+                Some(_) => {
+                    out.pop();
                 }
-                out.truncate(w);
-            } else if !rooted {
-                // cannot backtrack, but not rooted, so append .. element
-                if !out.is_empty() {
-                    out.push(SEP);
-                }
-                out.push(DOT);
-                out.push(DOT);
-                dotdot = out.len();
-            }
-        } else {
-            // real path element
-            // add slash if needed
-            if rooted && out.len() != 1 || !rooted && !out.is_empty() {
-                out.push(SEP);
-            }
-            while r < n && path[r] != SEP {
-                out.push(path[r]);
-                r += 1;
-            }
+                None => out.push(comp),
+            },
+            comp => out.push(comp),
         }
     }
 
-    // Turn empty string into "."
     if out.is_empty() {
-        out.push(DOT);
+        out.push(Component::CurDir);
     }
-    out
+
+    out.iter().fold(PathBuf::new(), |mut out, segment| {
+        out.push(segment);
+
+        out
+    })
 }
 
 #[cfg(test)]
@@ -135,7 +87,7 @@ mod tests {
 
     #[test]
     fn test_empty_path_is_current_dir() {
-        assert_eq!(clean(""), ".");
+        assert_eq!(clean(""), PathBuf::from("."));
     }
 
     #[test]
@@ -143,7 +95,7 @@ mod tests {
         let tests = vec![(".", "."), ("..", ".."), ("/", "/")];
 
         for test in tests {
-            assert_eq!(clean(test.0), test.1);
+            assert_eq!(clean(test.0), PathBuf::from(test.1));
         }
     }
 
@@ -164,7 +116,7 @@ mod tests {
         ];
 
         for test in tests {
-            assert_eq!(clean(test.0), test.1);
+            assert_eq!(clean(test.0), PathBuf::from(test.1));
         }
     }
 
@@ -180,7 +132,7 @@ mod tests {
         ];
 
         for test in tests {
-            assert_eq!(clean(test.0), test.1);
+            assert_eq!(clean(test.0), PathBuf::from(test.1));
         }
     }
 
@@ -207,7 +159,7 @@ mod tests {
         ];
 
         for test in tests {
-            assert_eq!(clean(test.0), test.1);
+            assert_eq!(clean(test.0), PathBuf::from(test.1));
         }
     }
 
@@ -217,5 +169,22 @@ mod tests {
             PathBuf::from("/test/../path/").clean(),
             PathBuf::from("/path")
         );
+    }
+
+    #[test]
+    #[cfg(target_os = "windows")]
+    fn test_windows_paths() {
+        let tests = vec![
+            ("\\..", "\\"),
+            ("\\..\\test", "\\test"),
+            ("test\\..", "."),
+            ("test\\path\\..\\..\\..", ".."),
+            ("test\\path/..\\../another\\path", "another\\path"), // Mixed
+            ("/dir\\../otherDir/test.json", "/otherDir/test.json"), // User example
+        ];
+
+        for test in tests {
+            assert_eq!(clean(test.0), PathBuf::from(test.1));
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,11 +59,13 @@ where
             Component::CurDir => (),
             Component::ParentDir => match out.last() {
                 Some(Component::RootDir) => (),
-                Some(Component::CurDir) | Some(Component::ParentDir) => out.push(comp),
-                Some(_) => {
+                Some(Component::Normal(_)) => {
                     out.pop();
                 }
-                None => out.push(comp),
+                None
+                | Some(Component::CurDir)
+                | Some(Component::ParentDir)
+                | Some(Component::Prefix(_)) => out.push(comp),
             },
             comp => out.push(comp),
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,15 +69,11 @@ where
         }
     }
 
-    if out.is_empty() {
-        out.push(Component::CurDir);
+    if !out.is_empty() {
+        out.iter().collect()
+    } else {
+        PathBuf::from(".")
     }
-
-    out.iter().fold(PathBuf::new(), |mut out, segment| {
-        out.push(segment);
-
-        out
-    })
 }
 
 #[cfg(test)]


### PR DESCRIPTION
We ran into this because we wanted the algorithm to work against `PathBuf` instances on Windows which usually end up being separated by backslash instead of slash. (We currently workaround this using `.replace("\\", "/")`.)

As it seemed straight-forward to implement the lexicographical algorithm using the component iterator found in the standard library, we decided to present this as a possible change here instead of rolling our own. Of course, it is much slower than the current highly optimized version, e.g.
```
clean                   time:   [427.76 ns 428.61 ns 429.42 ns]                  
                        change: [+392.31% +393.45% +394.47%] (p = 0.00 < 0.05)
                        Performance has regressed.
```
On the other hand, it could fix #4, #8 and #9 with the code remaining relatively simple.

Please let us know if this is something you would consider for this crate or whether this goes against it intended use cases.

cc @mlange-42